### PR TITLE
First pass at user comments for posts.

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -27,9 +27,10 @@
 - Views
     - [x] Index
     - [x] Trash/Restore/Destroy
-    - [ ] Edit / Create
-    - [ ] Enums
-    - [ ] Components
+    - [x] Create
+    - [ ] Edit
+    - [x] Enums
+    - [x] Components
 
 ## Users CRUD
 

--- a/app/Http/Actions/Comment/CreateComment.php
+++ b/app/Http/Actions/Comment/CreateComment.php
@@ -1,0 +1,73 @@
+<?php
+namespace App\Http\Actions\Comment;
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Str;
+use Illuminate\Support\Facades\Date;
+use Illuminate\Validation\Rule;
+
+use App\Models\Post;
+use App\Models\Comment;
+use App\Enums\CommentStatus;
+
+class CreateComment
+{
+    public function __invoke( Post $post, Request $request ): Comment
+    {
+        return $this->create( $post, $request );
+    }
+
+    public function create( Post $post, Request $request ): Comment
+    {
+        $request->merge( [
+            'user_id' => $request->user()?->id,
+            'post_id' => $post->id,
+            'status' => $this->prepareStatus( $request?->status ),
+            'ip' => $request->ip(),
+            'ua' => $request->server('HTTP_USER_AGENT'),
+            'name' => $this->prepareName( $request->name ),
+            'body' => $this->prepareBody( $request->body ),
+        ] );
+
+        $validated = $request->validate( [
+            'user_id' => 'nullable|exists:users,id',
+            'post_id' => 'required|exists:posts,id',
+            'parent_id' => 'nullable|exists:comments,id',
+            'status' => [
+                'required',
+                Rule::enum( CommentStatus::class ),
+            ],
+            'ip' => 'nullable|ip',
+            'ua' => 'nullable',
+            'name' => 'required',
+            'email' => 'required|email',
+            'url' => 'nullable|url',
+            'body' => 'required',
+        ] );
+
+        $comment = $post->comments()->create( $validated );
+
+        return $comment;
+    }
+
+    protected function prepareStatus( string|null $status = 'published' )
+    {
+        // To do: more sophisiticaed status setting logic here.
+
+        if ( ! CommentStatus::tryFrom( $status ) ) {
+            $status = CommentStatus::PUBLISHED->value;
+        }
+
+        return $status;
+    }
+
+    protected function prepareName( string $name = '' )
+    {
+        return Str::of( $name )->stripTags();
+    }
+
+    protected function prepareBody( string $body = '' )
+    {
+        return Str::of( $body )->stripTags();
+    }
+}

--- a/app/Http/Actions/Comment/UpdateComment.php
+++ b/app/Http/Actions/Comment/UpdateComment.php
@@ -1,0 +1,15 @@
+<?php
+namespace App\Http\Actions\Comment;
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Str;
+use Illuminate\Support\Facades\Date;
+use Illuminate\Validation\Rule;
+
+use App\Models\Comment;
+use App\Enums\CommentStatus;
+
+class UpdateComment
+{
+
+}

--- a/app/Http/Controllers/CommentController.php
+++ b/app/Http/Controllers/CommentController.php
@@ -7,6 +7,9 @@ use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\Controller;
 
 use App\Models\Comment;
+use App\Models\Post;
+use App\Http\Actions\Comment\CreateComment;
+use App\Http\Actions\Comment\UpdateComment;
 
 class CommentController
 {
@@ -22,7 +25,7 @@ class CommentController
                     return $query->where( 'status', $request->status );
                 }
             } )
-            ->orderBy('published_at', 'desc')
+            ->latest()
             ->with( 'post' )
             ->with( 'parent' )
             ->with( 'replies' )
@@ -52,9 +55,22 @@ class CommentController
 
     }
 
-    public function update()
+    public function storePublic( Post $post, Request $request, CreateComment $createComment )
     {
+        if ( $comment = $createComment( $post, $request ) ) {
+            return back()
+                ->withFragment( 'comment-' . $comment->id )
+                ->with( 'success', __('Comment Created') );
+        }
 
+        return back()->withErrors( [ 'message'=> 'Comment could not be created.' ] );
+    }
+
+    public function update( Comment $comment, Request $request, UpdateComment $updateComment )
+    {
+        $comment = $updateComment( $comment, $request );
+
+        return to_route( 'admin.comments.edit', [ 'comment' => $comment ] );
     }
 
     public function trash( Comment $comment )

--- a/app/Http/Controllers/ThemeController.php
+++ b/app/Http/Controllers/ThemeController.php
@@ -3,6 +3,7 @@ namespace App\Http\Controllers;
 
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
+use Illuminate\Contracts\Database\Eloquent\Builder;
 
 use App\Http\Controllers\Controller;
 use App\Models\Page;
@@ -31,7 +32,7 @@ class ThemeController extends Controller
 
     public function singular( string $slug, Page $page, Post $post )
     {
-        if ( $page = $page->published()->slug( $slug )->first() ) {
+        if ( $page = $page->published()->slug( $slug )->with( 'user' )->first() ) {
             return view()->first(
                 [
                     'theme::page-' . $page->slug,
@@ -43,7 +44,19 @@ class ThemeController extends Controller
             );
         }
 
-        if ( $post = $post->published()->slug( $slug )->first() ) {
+        // Eager load Comments and User with Post
+        $post = $post->query()
+                ->published()
+                ->slug( $slug )
+                ->with( [
+                    'comments' => function( Builder $query ) {
+                        $query->whereNull( 'parent_id' );
+                    },
+                    'user',
+                ] )
+                ->first();
+
+        if ( $post ) {
             return view()->first(
                 [
                     'theme::post-' . $post->slug,
@@ -70,7 +83,11 @@ class ThemeController extends Controller
 
     public function posts()
     {
-        $posts = Post::query()->latest()->published()->get();
+        $posts = Post::query()
+            ->latest()
+            ->published()
+            ->with( 'user' )
+            ->paginate( 10 );
 
         return view()->first(
             [

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -25,8 +25,8 @@ class Post extends Model
         'slug',
         'published_at',
         'comment_count',
+        'comments_on',
         'status',
-        'allow_comments',
     ];
 
     protected function casts(): array
@@ -86,7 +86,7 @@ class Post extends Model
 
     public function author()
     {
-        return $this->user;
+        return Attribute::make( $this->user );
     }
 
     public function scopePublished( Builder $query )

--- a/database/migrations/0001_01_01_000006_create_comments_table.php
+++ b/database/migrations/0001_01_01_000006_create_comments_table.php
@@ -30,8 +30,10 @@ return new class extends Migration
                 ->constrained()
                 ->cascadeOnDelete();
             $table->string( 'status', 20 ); //published, pending, spam
-            $table->ipAddress( 'ip' );
-            $table->string( 'ua', 255 );
+            $table->ipAddress( 'ip' )
+                ->nullable();
+            $table->string( 'ua', 255 )
+                ->nullable();
             $table->string( 'name', 50 );
             $table->string( 'email', 50 );
             $table->string( 'url', 50 )

--- a/resources/views/components/comment/form.blade.php
+++ b/resources/views/components/comment/form.blade.php
@@ -1,0 +1,34 @@
+@props([
+    'post',
+    'heading' => __( 'Leave a Reply' ),
+    'submitText' => __( 'Submit Comment' ),
+])
+<div {{ $attributes->merge([ 'id' => 'respond' ]) }}>
+    <h3>{{ $heading }}</h3>
+    <form method="post" action="{{ route( 'public.comments.store', [ 'post' => $post ] ) }}" class="comment-form" name="comment-form">
+        @csrf
+        @method('PUT')
+
+        @auth
+        <p>{{ __( 'Logged in as :display_name', [ 'display_name' => auth()->user()->display_name ] ) }}</p>
+        <input type="hidden" name="name" value="{{ auth()->user()->display_name }}" />
+        <input type="hidden" name="email" value="{{ auth()->user()->email }}" />
+        <input type="hidden" name="url" value="{{ auth()->user()->website }}" />
+        @endauth
+
+        <textarea class="comment-form-body" name="body" rows="8" cols="45" required></textarea>
+
+        @guest
+        <label for="comment-form-name">{{ __( 'Name (required)' ) }}</label>
+        <input type="text" class="comment-form-name" id="comment-form-name" name="name" required />
+
+        <label for="comment-form-email">{{ __( 'Email (required)' ) }}</label>
+        <input type="email" class="comment-form-email" id="comment-form-email" name="email" required />
+
+        <label for="comment-form-url">{{ __( 'Website' ) }}</label>
+        <input type="url" class="comment-form-url" id="comment-form-url" name="url" />
+        @endguest
+
+        <button type="submit">{{ $submitText }}</button>
+    </form>
+</div>

--- a/resources/views/themes/buena-vista/post.blade.php
+++ b/resources/views/themes/buena-vista/post.blade.php
@@ -10,19 +10,26 @@
                 format: 'markdown',
             )
         !!}
+    </article>
 
     @if( $post->comments->isNotEmpty() )
     <div id="comments">
         <h3>{{ __( 'Comments' ) }}</h3>
         <ul class="comment-list">
             @foreach( $post->comments as $comment )
-                <li id="{{ $comment->id }}">
-                    <p>{{ __( 'By :name on :date', [ 'name' => $comment->name, 'date' => $comment->created_at ] ) }}</p>
+                <li id="comment-{{ $comment->id }}">
+                    <p><a href="#comment-{{ $comment->id }}">#</a> {{ __( 'By :name on :date', [ 'name' => $comment->name, 'date' => $comment->created_at ] ) }}</p>
                     <p>{{ $comment->body }}
                 </li>
             @endforeach
         </ul>
     </div>
+    @endif
+
+    @if( $post->comments_on )
+    <x-comment.form :$post />
+    @elseif( $post->comments->isNotEmpty() )
+    <h3 id="respond">{{ __( 'Comments are closed' ) }}</h3>
     @endif
 
     <x-theme::footer />

--- a/routes/web.php
+++ b/routes/web.php
@@ -2,6 +2,7 @@
 use Illuminate\Support\Facades\Route;
 
 use App\Http\Controllers\SessionController;
+use App\Http\Controllers\CommentController;
 
 Route::get( '/login', [ SessionController::class, 'create' ] )->name( 'login' )->middleware( 'guest' );
 Route::put( '/login', [ SessionController::class, 'store' ] )->name( name: 'login.auth' );
@@ -21,6 +22,8 @@ Route::group(
         require 'admin/comments.php';
         //require 'admin/tags.php';
 } );
+
+Route::put( '/post/{post:slug}/comment', [ CommentController::class, 'storePublic' ] )->name( 'public.comments.store' );
 
 require 'theme/assets.php';
 require 'theme/templates.php';


### PR DESCRIPTION
The PR adds the ability for guests and logged in users to submit comments on posts.

Themes now have access to a global `<x-comment.form />` component. It needs access to a `Post` model in order to know where to submit to.

Usage looks like this, in `single.blade.php`:

```php
<x-comment.form :$post />
```

Eager loading on certain routes has been enabled for Posts. This helps us avoid n+1 problems, and also allows us to define parameters on the certain queries at the route level, so themes don't have to worry about it in the template files.

Comments are automatically given a value of "published". No further logic has been created for setting other statuses.

Further questions and details can be covered in comments on the PR.